### PR TITLE
chore: migrate eligible workflows to ubuntu-slim runner

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Generate GitHub App token
         id: generate-token


### PR DESCRIPTION
## Summary
Ubuntu Slim Runner は軽量・低コストなランナーで、以下のような軽量ワークフロー向きです:
- release-please / PR タイトル検証 / claude-code / tag 自動化 / 軽量 Node CI 等

制約 (15分タイムアウト / unprivileged container / 最小プリインツール) に合致するワークフローのみ対象としています。Gradle/Rust/Go/Dart/fastlane 等の重量ビルドは対象外です。

### 変更対象
- `.github/workflows/release-please.yml`

### 調査の詳細
関連調査タスク: yshrsmz 配下リポジトリの Slim Runner 化可能性調査 (2026-04-15 完了)

## Test plan
- [ ] PR 作成後、対象ワークフローが push/label/issue 等のトリガーで正常に動作することを確認
- [ ] claude-code 系は `timeout-minutes: 15` に抵触しないかモニタリング