### PR TITLE
ci: strip build metadata before passing java version to setup-java

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -33,6 +33,11 @@ runs:
         DISTRIBUTION=$(echo "$JAVA_VERSION_STRING" | cut -d'-' -f1)
         # Extract version (everything after the dash)
         VERSION=$(echo "$JAVA_VERSION_STRING" | cut -d'-' -f2-)
+        # Drop build metadata (everything from '+'). actions/setup-java demands an
+        # exact match when build metadata is present, but Adoptium's published
+        # version list does not carry the same suffix. Without metadata setup-java
+        # resolves via semver.satisfies, which still pins major.minor.patch.
+        VERSION="${VERSION%%+*}"
 
         echo "distribution=$DISTRIBUTION" >> "$GITHUB_OUTPUT"
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- `actions/setup-java` requires an exact match when the java version string carries build metadata (`+N.LTS`), but Adoptium's published version list doesn't carry the same suffix, causing `No matching version found` failures (see PR #89).
- Strip everything from `+` onward before passing the version to `setup-java`, matching the fix already applied in yshrsmz/since-android#690 (commit eea6501402124a930e87dd4619af747af4434110).

## Test plan
- [ ] CI passes on this PR